### PR TITLE
Actualizar logo y branding a Crepería O&E

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!-- ============================================================================
-404.html — Página No Encontrada de Crepería OyE
+404.html — Página No Encontrada de Crepería O&E
 ============================================================================ -->
 
 <!DOCTYPE html>
@@ -10,7 +10,7 @@
   ------------------------------------------------------------------------ -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🥞 Página No Encontrada - Crepería OyE</title>
+  <title>🥞 Página No Encontrada - Crepería O&amp;E</title>
   <meta name="description" content="Lo sentimos, la página que buscas no existe. Descubre nuestras crepas artesanales y experiencias gourmet.">
 
   <!-- ------------------------------------------------------------------------
@@ -41,7 +41,7 @@
 
       <p class="error-description">
         Parece que la crepa que buscabas se volteó antes de tiempo o nunca existió.
-        No te preocupes, en Crepería OyE tenemos combinaciones deliciosas esperándote.
+        No te preocupes, en Crepería O&amp;E tenemos combinaciones deliciosas esperándote.
       </p>
 
       <div class="error-code">

--- a/public/about.html
+++ b/public/about.html
@@ -1,5 +1,5 @@
 <!-- ============================================================================
-about.html — Página Nosotros Crepería OyE
+about.html — Página Nosotros Crepería O&E
 ============================================================================ -->
 
 <!DOCTYPE html>
@@ -10,8 +10,8 @@ about.html — Página Nosotros Crepería OyE
   ------------------------------------------------------------------------ -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🥞 Nosotros - Crepería OyE</title>
-  <meta name="description" content="Conoce la historia de Crepería OyE, nuestras recetas artesanales y el amor por las crepas hechas en Chimaltenango, Guatemala.">
+  <title>🥞 Nosotros - Crepería O&amp;E</title>
+  <meta name="description" content="Conoce la historia de Crepería O&amp;E, nuestras recetas artesanales y el amor por las crepas hechas en Chimaltenango, Guatemala.">
 
   <!-- ------------------------------------------------------------------------
        CSS global y específico
@@ -39,11 +39,11 @@ about.html — Página Nosotros Crepería OyE
     <!-- Historia / Imagen + Texto -->
     <div class="about-content">
       <div class="about-image">
-        <img src="/img/equipo-creperia.svg" alt="Chef Elena y el equipo de Crepería OyE preparando crepas" />
+        <img src="/img/equipo-creperia.svg" alt="Chef Elena y el equipo de Crepería O&amp;E preparando crepas" />
       </div>
       <div class="about-text">
         <h3>El comienzo de un sueño a la plancha</h3>
-        <p>Crepería OyE nació en la cocina de la chef Elena y su hermano Óscar, quienes heredaron de su abuela francesa la pasión por las masas finas y los rellenos hechos con ingredientes frescos. Durante años prepararon crepas para amigos y vecinos en Chimaltenango hasta que en 2010 decidieron abrir su primer pequeño local.</p>
+        <p>Crepería O&amp;E nació en la cocina de la chef Elena y su hermano Óscar, quienes heredaron de su abuela francesa la pasión por las masas finas y los rellenos hechos con ingredientes frescos. Durante años prepararon crepas para amigos y vecinos en Chimaltenango hasta que en 2010 decidieron abrir su primer pequeño local.</p>
         <p>Lo que inició con tres recetas familiares hoy se ha convertido en una experiencia gastronómica completa que combina sabores guatemaltecos con técnicas europeas. Cada mañana tostamos cacao, preparamos nuestras salsas caseras y amasamos la mezcla del día para que cada crepa salga dorada y perfecta.</p>
 
         <blockquote class="about-quote">
@@ -102,7 +102,7 @@ about.html — Página Nosotros Crepería OyE
         <div class="milestone">
           <div class="milestone-year">2010</div>
           <div class="milestone-content">
-            <h4>Crepería OyE abre sus puertas</h4>
+            <h4>Crepería O&amp;E abre sus puertas</h4>
             <p>Inauguramos nuestro primer local en Chimaltenango con un menú de crepas dulces, saladas y bebidas de autor.</p>
           </div>
         </div>
@@ -117,7 +117,7 @@ about.html — Página Nosotros Crepería OyE
           <div class="milestone-year">2023</div>
           <div class="milestone-content">
             <h4>Sabores que viajan</h4>
-            <p>Lanzamos combos para compartir y kits para preparar crepas en casa, llevando la experiencia OyE a toda Guatemala.</p>
+            <p>Lanzamos combos para compartir y kits para preparar crepas en casa, llevando la experiencia O&amp;E a toda Guatemala.</p>
           </div>
         </div>
       </div>

--- a/public/admin.html
+++ b/public/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>⚙️ Admin - Crepería OyE</title>
+  <title>⚙️ Admin - Crepería O&amp;E</title>
   <link rel="stylesheet" href="/css/global.css"/>
   <link rel="stylesheet" href="/css/admin.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>

--- a/public/cart.html
+++ b/public/cart.html
@@ -1,5 +1,5 @@
 <!-- ============================================================================
-cart.html — Página Carrito de Crepería OyE
+cart.html — Página Carrito de Crepería O&E
 ============================================================================ -->
 
 <!DOCTYPE html>
@@ -10,8 +10,8 @@ cart.html — Página Carrito de Crepería OyE
   ------------------------------------------------------------------------ -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🥞 Carrito - Crepería OyE</title>
-  <meta name="description" content="Revisa y gestiona tus crepas, bebidas y combos favoritos en el carrito de Crepería OyE.">
+  <title>🥞 Carrito - Crepería O&amp;E</title>
+  <meta name="description" content="Revisa y gestiona tus crepas, bebidas y combos favoritos en el carrito de Crepería O&amp;E.">
 
   <!-- ------------------------------------------------------------------------
        CSS global + específico

--- a/public/checkout.html
+++ b/public/checkout.html
@@ -1,5 +1,5 @@
 <!-- ============================================================================
-checkout.html — Página de Checkout Crepería OyE
+checkout.html — Página de Checkout Crepería O&E
 ============================================================================ -->
 
 <!DOCTYPE html>
@@ -7,8 +7,8 @@ checkout.html — Página de Checkout Crepería OyE
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🛒 Checkout - Crepería OyE</title>
-  <meta name="description" content="Revisa tu carrito y finaliza la compra de crepas, bebidas y combos de Crepería OyE.">
+  <title>🛒 Checkout - Crepería O&amp;E</title>
+  <meta name="description" content="Revisa tu carrito y finaliza la compra de crepas, bebidas y combos de Crepería O&amp;E.">
 
   <!-- CSS global y específico -->
   <link rel="stylesheet" href="/css/global.css"/>

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,5 +1,5 @@
 <!-- ============================================================================
-contact.html — Página Contacto Crepería OyE
+contact.html — Página Contacto Crepería O&E
 ============================================================================ -->
 
 <!DOCTYPE html>
@@ -10,8 +10,8 @@ contact.html — Página Contacto Crepería OyE
   ------------------------------------------------------------------------ -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🥞 Contacto - Crepería OyE</title>
-  <meta name="description" content="Contáctanos en Crepería OyE. Estamos en Chimaltenango, Guatemala. Envíanos un mensaje, haz tu pedido o reserva.">
+  <title>🥞 Contacto - Crepería O&amp;E</title>
+  <meta name="description" content="Contáctanos en Crepería O&amp;E. Estamos en Chimaltenango, Guatemala. Envíanos un mensaje, haz tu pedido o reserva.">
 
   <!-- ------------------------------------------------------------------------
        CSS global + específico

--- a/public/css/checkout.css
+++ b/public/css/checkout.css
@@ -1,5 +1,5 @@
 /* ============================================================================
-checkout.css — estilos para Checkout Crepería OyE
+checkout.css — estilos para Checkout Crepería O&E
 ============================================================================ */
 
 /* Contenedor principal */

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>📊 Dashboard - Crepería OyE</title>
+  <title>📊 Dashboard - Crepería O&amp;E</title>
   <link rel="stylesheet" href="/css/global.css"/>
   <link rel="stylesheet" href="/css/admin.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>

--- a/public/factura.html
+++ b/public/factura.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Factura - Crepería OyE</title>
+  <title>Factura - Crepería O&amp;E</title>
 
   <link rel="stylesheet" href="/css/global.css"/>
   <link rel="stylesheet" href="/css/factura.css"/>
@@ -21,7 +21,7 @@
       <div class="brand-badge" aria-hidden="true">CO</div>
       <div class="header-text">
         <h1 id="invoice-title">Factura</h1>
-        <p>Crepería OyE · RFC/NIT: 1234567-OYE · Tel: (502) 5555-5555</p>
+        <p>Crepería O&amp;E · RFC/NIT: 1234567-OE · Tel: (502) 5555-5555</p>
       </div>
     </header>
 

--- a/public/img/equipo-creperia.svg
+++ b/public/img/equipo-creperia.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 380" role="img" aria-labelledby="title desc">
-  <title id="title">Equipo Crepería OyE</title>
-  <desc id="desc">Ilustración de la fundadora de Crepería OyE preparando crepas sobre una plancha.</desc>
+  <title id="title">Equipo Crepería O&amp;E</title>
+  <desc id="desc">Ilustración de la fundadora de Crepería O&amp;E preparando crepas sobre una plancha.</desc>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#fff7ed" />

--- a/public/img/hero-creperia.svg
+++ b/public/img/hero-creperia.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 420" role="img" aria-labelledby="title desc">
-  <title id="title">Ilustración hero de Crepería OyE</title>
+  <title id="title">Ilustración hero de Crepería O&amp;E</title>
   <desc id="desc">Ilustración vectorial de una crepa servida con frutas frescas, chocolate y decoración cálida.</desc>
   <defs>
     <linearGradient id="bg-gradient" x1="0%" y1="0%" x2="100%" y2="100%">

--- a/public/img/logo-crepas-oe.svg
+++ b/public/img/logo-crepas-oe.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="pancake" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f6d58f" />
+      <stop offset="100%" stop-color="#e6a959" />
+    </linearGradient>
+    <linearGradient id="pancakeShadow" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f9e4b7" />
+      <stop offset="100%" stop-color="#d8933c" />
+    </linearGradient>
+    <linearGradient id="chocolate" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#5c2a1a" />
+      <stop offset="100%" stop-color="#2f140b" />
+    </linearGradient>
+    <radialGradient id="berry" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#b4062b" />
+      <stop offset="100%" stop-color="#7a0319" />
+    </radialGradient>
+    <radialGradient id="blueberry" cx="45%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#4c6ac2" />
+      <stop offset="100%" stop-color="#2a3b73" />
+    </radialGradient>
+    <linearGradient id="leaf" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#62b44a" />
+      <stop offset="100%" stop-color="#2f7b21" />
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="16" flood-color="#b88a4c" flood-opacity="0.35" />
+    </filter>
+  </defs>
+  <rect width="1024" height="1024" fill="#ffffff" rx="80" />
+  <path
+    d="M 982.000 512.000 Q 956.047 541.104 928.407 566.821 Q 948.449 598.815 965.985 633.645 Q 933.384 655.041 900.029 672.727 Q 911.108 708.818 919.032 747.000 Q 882.004 759.229 845.208 767.680 Q 846.569 805.409 844.340 844.340 Q 805.409 846.569 767.680 845.208 Q 759.229 882.004 747.000 919.032 Q 708.818 911.108 672.727 900.029 Q 655.041 933.384 633.645 965.985 Q 598.815 948.449 566.821 928.407 Q 541.104 956.047 512.000 982.000 Q 482.896 956.047 457.179 928.407 Q 425.185 948.449 390.355 965.985 Q 368.959 933.384 351.273 900.029 Q 315.182 911.108 277.000 919.032 Q 264.771 882.004 256.320 845.208 Q 218.591 846.569 179.660 844.340 Q 177.431 805.409 178.792 767.680 Q 141.996 759.229 104.968 747.000 Q 112.892 708.818 123.971 672.727 Q 90.616 655.041 58.015 633.645 Q 75.551 598.815 95.593 566.821 Q 67.953 541.104 42.000 512.000 Q 67.953 482.896 95.593 457.179 Q 75.551 425.185 58.015 390.355 Q 90.616 368.959 123.971 351.273 Q 112.892 315.182 104.968 277.000 Q 141.996 264.771 178.792 256.320 Q 177.431 218.591 179.660 179.660 Q 218.591 177.431 256.320 178.792 Q 264.771 141.996 277.000 104.968 Q 315.182 112.892 351.273 123.971 Q 368.959 90.616 390.355 58.015 Q 425.185 75.551 457.179 95.593 Q 482.896 67.953 512.000 42.000 Q 541.104 67.953 566.821 95.593 Q 598.815 75.551 633.645 58.015 Q 655.041 90.616 672.727 123.971 Q 708.818 112.892 747.000 104.968 Q 759.229 141.996 767.680 178.792 Q 805.409 177.431 844.340 179.660 Q 846.569 218.591 845.208 256.320 Q 882.004 264.771 919.032 277.000 Q 911.108 315.182 900.029 351.273 Q 933.384 368.959 965.985 390.355 Q 948.449 425.185 928.407 457.179 Q 956.047 482.896 982.000 512.000 Z"
+    fill="none"
+    stroke="#1d1d1d"
+    stroke-width="20"
+  />
+  <circle cx="512" cy="512" r="360" fill="#ffffff" stroke="#1d1d1d" stroke-width="8" />
+  <g filter="url(#shadow)">
+    <ellipse cx="512" cy="646" rx="220" ry="48" fill="#d27c2d" opacity="0.35" />
+  </g>
+  <g transform="translate(0,40)">
+    <path d="M302 590c70 60 360 60 420 0 12-12 0-32-18-34-32-4-356-4-386 0-20 2-34 22-16 34z" fill="url(#pancake)" stroke="#c37b2f" stroke-width="6" />
+    <path d="M322 544c66 56 324 56 390 0 12-10 2-30-16-32-60-8-296-8-348 0-20 2-32 20-26 32z" fill="url(#pancakeShadow)" stroke="#c37b2f" stroke-width="6" />
+    <path d="M340 498c56 46 292 46 352 0 12-10 6-28-10-30-70-10-262-10-320 0-18 2-32 20-22 30z" fill="url(#pancake)" stroke="#c37b2f" stroke-width="6" />
+    <path d="M360 462c40 34 250 34 306 0 14-8 12-26 0-28-62-10-220-10-276 0-16 2-22 20-30 28z" fill="url(#pancakeShadow)" stroke="#c37b2f" stroke-width="6" />
+    <path d="M392 432c30 24 200 24 244 0 8-4 12-18 4-22-44-18-202-18-252 0-10 4-8 18 4 22z" fill="url(#pancake)" stroke="#c37b2f" stroke-width="6" />
+    <path d="M420 404c20 12 150 12 184 0 14-6 12-20 4-26-26-18-160-18-188 0-10 6-12 20 0 26z" fill="url(#pancakeShadow)" stroke="#c37b2f" stroke-width="6" />
+    <path d="M436 374c16 10 132 10 160 0 10-4 14-18 8-24-20-16-144-16-172 0-8 6-6 20 4 24z" fill="url(#pancake)" stroke="#c37b2f" stroke-width="6" />
+  </g>
+  <path d="M408 436c76 26 166 24 236-6 32-14 78 58 2 98-62 32-86 68-78 104 6 22-52 46-102 14-52-34-92-30-120-12-36 22-66-32-18-68 50-38 40-98 80-126z" fill="url(#chocolate)" stroke="#38160b" stroke-width="6" />
+  <g transform="translate(46,-40)">
+    <path d="M568 366c32-42 76-70 102-68 10 0 18 12 12 22-16 26-54 54-90 66-10 4-20-6-24-20z" fill="url(#leaf)" stroke="#1c5814" stroke-width="6" />
+    <path d="M612 368c24-32 54-52 72-52 8 0 14 10 10 18-10 20-38 40-64 50-8 2-16-4-18-16z" fill="url(#leaf)" stroke="#1c5814" stroke-width="6" />
+  </g>
+  <g transform="translate(-40,-54)">
+    <ellipse cx="560" cy="356" rx="86" ry="80" fill="url(#berry)" stroke="#68061a" stroke-width="8" />
+    <path d="M516 320c14 12 54 12 70 0" fill="none" stroke="#f4a3b2" stroke-width="10" stroke-linecap="round" />
+    <circle cx="516" cy="340" r="12" fill="#f9c5c5" opacity="0.4" />
+    <circle cx="592" cy="332" r="10" fill="#f9c5c5" opacity="0.3" />
+  </g>
+  <g transform="translate(128,-10)">
+    <ellipse cx="520" cy="350" rx="64" ry="60" fill="url(#blueberry)" stroke="#182854" stroke-width="8" />
+    <ellipse cx="460" cy="336" rx="52" ry="50" fill="url(#blueberry)" stroke="#182854" stroke-width="8" />
+    <circle cx="492" cy="322" r="14" fill="#91a8ff" opacity="0.35" />
+    <circle cx="440" cy="318" r="12" fill="#91a8ff" opacity="0.3" />
+  </g>
+  <text x="512" y="212" text-anchor="middle" font-size="140" font-weight="700" font-family="'Playfair Display', 'Georgia', serif" fill="#1d1d1d">Crepas</text>
+  <text x="512" y="884" text-anchor="middle" font-size="120" font-family="'Playfair Display', 'Georgia', serif" fill="#1d1d1d">O &amp; E</text>
+</svg>

--- a/public/img/logo-oye-mark.svg
+++ b/public/img/logo-oye-mark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-labelledby="title desc">
-  <title id="title">Isotipo Crepería OyE</title>
-  <desc id="desc">Icono circular con una crepa enrollada y destellos cálidos representando la marca Crepería OyE.</desc>
+  <title id="title">Isotipo Crepería O&amp;E</title>
+  <desc id="desc">Icono circular con una crepa enrollada y destellos cálidos representando la marca Crepería O&amp;E.</desc>
   <defs>
     <linearGradient id="mark-bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#fff7ed" />

--- a/public/img/logo-oye.svg
+++ b/public/img/logo-oye.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 220" role="img" aria-labelledby="title desc">
-  <title id="title">Logotipo Crepería OyE</title>
-  <desc id="desc">Logotipo con un cono de crepa estilizado y tipografía cálida para la marca Crepería OyE.</desc>
+  <title id="title">Logotipo Crepería O&amp;E</title>
+  <desc id="desc">Logotipo con un cono de crepa estilizado y tipografía cálida para la marca Crepería O&amp;E.</desc>
   <defs>
     <linearGradient id="grad-bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#fff3e0" />
@@ -35,6 +35,6 @@
   </g>
   <g transform="translate(20 188)">
     <text x="0" y="0" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="28" font-weight="700" fill="#b45309" letter-spacing="0.02em">Crepería</text>
-    <text x="0" y="28" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="44" font-weight="700" fill="url(#grad-outline)" letter-spacing="0.03em">OyE</text>
+    <text x="0" y="28" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="44" font-weight="700" fill="url(#grad-outline)" letter-spacing="0.03em">O&amp;E</text>
   </g>
 </svg>

--- a/public/img/product-placeholder.svg
+++ b/public/img/product-placeholder.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 220" role="img" aria-labelledby="title desc">
-  <title id="title">Producto Crepería OyE</title>
-  <desc id="desc">Placeholder ilustrado con elementos de crepas para productos de la Crepería OyE.</desc>
+  <title id="title">Producto Crepería O&amp;E</title>
+  <desc id="desc">Placeholder ilustrado con elementos de crepas para productos de la Crepería O&amp;E.</desc>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#fff7ed" />
@@ -22,5 +22,5 @@
     <path d="M64 54c10 10 28 16 52 16s42-6 52-16" fill="none" stroke="url(#accent)" stroke-width="10" stroke-linecap="round" opacity="0.7" />
     <path d="M58 72c12 10 32 16 58 16s46-6 58-16" fill="none" stroke="#f97316" stroke-width="8" stroke-linecap="round" opacity="0.4" />
   </g>
-  <text x="160" y="196" text-anchor="middle" font-family="'Poppins','Segoe UI',sans-serif" font-size="26" font-weight="700" fill="#b45309">Crepería OyE</text>
+  <text x="160" y="196" text-anchor="middle" font-family="'Poppins','Segoe UI',sans-serif" font-size="26" font-weight="700" fill="#b45309">Crepería O&amp;E</text>
 </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Crepería OyE</title>
+  <title>Crepería O&amp;E</title>
   <meta name="description" content="Disfruta de crepas artesanales dulces y saladas, bebidas calientes y frías, además de toppings irresistibles.">
   <link rel="stylesheet" href="/css/global.css"/>
   <link rel="stylesheet" href="/css/index.css"/>
@@ -16,10 +16,10 @@
   <section class="hero container">
     <div class="hero-text">
       <div class="brand-badge">
-        <img src="/img/logo-oye.svg" alt="Logotipo oficial de Crepería OyE" />
+        <img src="/img/logo-crepas-oe.svg" alt="Logotipo oficial de Crepería O&amp;E" />
       </div>
       <h1>Crepas hechas a mano con sabor y tradición</h1>
-      <p>En Crepería OyE, preparamos crepas artesanales con masa fresca, rellenos únicos y salsas caseras. Descubre nuestras combinaciones dulces, saladas y opciones personalizables.</p>
+      <p>En Crepería O&amp;E, preparamos crepas artesanales con masa fresca, rellenos únicos y salsas caseras. Descubre nuestras combinaciones dulces, saladas y opciones personalizables.</p>
       <a href="store.html" class="btn">Explorar Catálogo</a>
     </div>
     <div class="hero-img">
@@ -83,7 +83,7 @@
         <!-- Testimonio 3 -->
         <div class="testimonial-card">
           <div class="testimonial-text">
-            "El proceso de compra fue rapidísimo y las crepas llegaron perfectas. ¡Definitivamente recomiendo Crepería OyE!"
+            "El proceso de compra fue rapidísimo y las crepas llegaron perfectas. ¡Definitivamente recomiendo Crepería O&amp;E!"
           </div>
           <div class="testimonial-author">
             <div class="testimonial-avatar">CR</div>

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,5 +1,5 @@
   // ============================================================================
-  // dashboard.js - Crepería OyE
+  // dashboard.js - Crepería O&E
   // ============================================================================
 
   const TOKEN_KEY = 'authToken';
@@ -568,7 +568,7 @@ async function exportDashboardToExcel() {
     createMonthlySummarySheet(workbook, dashboardData);
     
     // Generar el archivo
-    const fileName = `Dashboard_Creperia_OyE_${getCurrentDateFormatted()}.xlsx`;
+    const fileName = `Dashboard_Creperia_OE_${getCurrentDateFormatted()}.xlsx`;
     XLSX.writeFile(workbook, fileName);
     
     // Notificar éxito
@@ -870,7 +870,7 @@ async function exportDashboardToExcelWithCharts() {
     const workbook = new ExcelJS.Workbook();
     
     // Configuración del libro
-    workbook.creator = 'Crepería OyE';
+    workbook.creator = 'Crepería O&E';
     workbook.created = new Date();
     workbook.modified = new Date();
     
@@ -894,7 +894,7 @@ async function exportDashboardToExcelWithCharts() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `Dashboard_Creperia_OyE_${getCurrentDateFormatted()}.xlsx`;
+    link.download = `Dashboard_Creperia_OE_${getCurrentDateFormatted()}.xlsx`;
     document.body.appendChild(link);
     link.click();
     link.remove();

--- a/public/js/factura.js
+++ b/public/js/factura.js
@@ -32,7 +32,7 @@
 
     // Datos “seller” (puedes reemplazar por los reales o traerlos del backend)
     const seller = {
-      name: 'Crepería OyE',
+      name: 'Crepería O&E',
       nit: '1234567-OYE',
       phone: '(502) 5555-5555'
     };

--- a/public/js/global.js
+++ b/public/js/global.js
@@ -44,10 +44,10 @@ const headerHTML = `
     <div class="container">
       <nav class="navbar">
         <a href="index.html" class="logo">
-          <img src="/img/logo-oye-mark.svg" alt="" aria-hidden="true" />
+          <img src="/img/logo-crepas-oe.svg" alt="Logotipo Crepería O&amp;E" aria-hidden="true" />
           <span class="logo-text">
             <span>Crepería</span>
-            <span>OyE</span>
+            <span>O&amp;E</span>
           </span>
         </a>
         <ul class="nav-links">
@@ -84,7 +84,7 @@ const headerHTML = `
       <div class="container">
         <div class="footer-grid">
           <div class="footer-column">
-            <h3>Crepería OyE</h3>
+            <h3>Crepería O&amp;E</h3>
             <p>Crepas artesanales con ingredientes frescos y locales.</p>
             <div class="social" aria-label="Redes sociales">
               <a href="#" class="social-icon fb" title="Facebook"><i class="fab fa-facebook-f"></i></a>
@@ -116,7 +116,7 @@ const headerHTML = `
           </div>
         </div>
         <div class="copyright">
-          <p>&copy; 2025 Crepería OyE. Todos los derechos reservados.</p>
+          <p>&copy; 2025 Crepería O&amp;E. Todos los derechos reservados.</p>
         </div>
       </div>
     </footer>

--- a/public/login.html
+++ b/public/login.html
@@ -4,8 +4,8 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🥞 Iniciar Sesión - Crepería OyE</title>
-  <meta name="description" content="Inicia sesión en tu cuenta de Crepería OyE para disfrutar de beneficios exclusivos y gestionar tus pedidos de crepas.">
+  <title>🥞 Iniciar Sesión - Crepería O&amp;E</title>
+  <meta name="description" content="Inicia sesión en tu cuenta de Crepería O&amp;E para disfrutar de beneficios exclusivos y gestionar tus pedidos de crepas.">
 
   <link rel="stylesheet" href="/css/global.css"/>
   <link rel="stylesheet" href="/css/login.css"/>

--- a/public/register.html
+++ b/public/register.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Crear cuenta — Crepería OyE</title>
+  <title>Crear cuenta — Crepería O&amp;E</title>
   <link rel="stylesheet" href="/css/global.css"/>
   <link rel="stylesheet" href="/css/register.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>

--- a/public/store.html
+++ b/public/store.html
@@ -1,5 +1,5 @@
 <!-- ============================================================================
-store.html — Página Tienda Crepería OyE
+store.html — Página Tienda Crepería O&E
 ============================================================================ -->
 
 <!DOCTYPE html>
@@ -10,8 +10,8 @@ store.html — Página Tienda Crepería OyE
   ------------------------------------------------------------------------ -->
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>🥞 Tienda - Crepería OyE</title>
-  <meta name="description" content="Explora nuestras crepas dulces y saladas, bebidas artesanales y combos especiales de Crepería OyE.">
+  <title>🥞 Tienda - Crepería O&amp;E</title>
+  <meta name="description" content="Explora nuestras crepas dulces y saladas, bebidas artesanales y combos especiales de Crepería O&amp;E.">
 
   <!-- ------------------------------------------------------------------------
        CSS global y específico

--- a/server.js
+++ b/server.js
@@ -1103,7 +1103,7 @@ const createDashboardCsv = (data) => {
   const lines = [];
   const formatCurrency = value => `Q${Number(value || 0).toFixed(2)}`;
 
-  lines.push(escapeCsvValue('Reporte Dashboard Crepería OyE'));
+  lines.push(escapeCsvValue('Reporte Dashboard Crepería O&E'));
   lines.push(`${escapeCsvValue('Generado')},${escapeCsvValue(new Date().toISOString())}`);
   lines.push('');
   lines.push(`${escapeCsvValue('Periodo')},${escapeCsvValue('Desde')},${escapeCsvValue('Hasta')}`);


### PR DESCRIPTION
## Summary
- add the new Crepería O&E logo illustration and hook it into the shared navigation
- refresh brand references across customer pages and assets to use the updated naming
- align dashboard exports and invoice branding with the new identity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e602365ab08326814cebb16c9043cb