### PR TITLE
Add rectification table to cost estimator

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -299,6 +299,25 @@
                     <tbody id="cost-coefficient-body"></tbody>
                   </table>
                 </section>
+
+                <section class="cost-result">
+                  <header>
+                    <h3><i class="fas fa-arrows-rotate"></i> Rectificación del costo unitario estimado</h3>
+                    <p class="cost-result-month" data-month-label>MES EN CURSO</p>
+                  </header>
+                  <table class="table cost-table">
+                    <thead>
+                      <tr>
+                        <th>Elementos</th>
+                        <th>Costo estimado unitario</th>
+                        <th>Coeficiente rectificador</th>
+                        <th>Cifra de corrección</th>
+                        <th>Costo unitario corregido</th>
+                      </tr>
+                    </thead>
+                    <tbody id="cost-rectification-body"></tbody>
+                  </table>
+                </section>
               </div>
             </div>
           </div>

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -242,6 +242,7 @@ function initCostCalculator() {
 
     const varianceBody = document.getElementById('cost-variance-body');
     const coefficientBody = document.getElementById('cost-coefficient-body');
+    const rectificationBody = document.getElementById('cost-rectification-body');
 
     const totals = {
       estimated: 0,
@@ -256,12 +257,16 @@ function initCostCalculator() {
     if (coefficientBody) {
       coefficientBody.innerHTML = '';
     }
+    if (rectificationBody) {
+      rectificationBody.innerHTML = '';
+    }
 
     COST_ELEMENTS.forEach((element, index) => {
       const estimated = Number.isFinite(estimatedTotals[index]) ? estimatedTotals[index] : 0;
       const real = Number.isFinite(monthlyCosts[index]) ? monthlyCosts[index] : 0;
       const variation = real - estimated;
       const status = getVariationStatus(variation);
+      const unitEstimated = Number.isFinite(unitCosts[index]) ? unitCosts[index] : 0;
 
       totals.estimated += estimated;
       totals.real += real;
@@ -290,6 +295,20 @@ function initCostCalculator() {
           <td><span class="status ${status.className}">${status.label}</span></td>
         `;
         coefficientBody.appendChild(row);
+
+        if (rectificationBody) {
+          const correctionFigure = unitEstimated * coefficient;
+          const correctedUnit = unitEstimated + correctionFigure;
+          const rectRow = document.createElement('tr');
+          rectRow.innerHTML = `
+            <td>${element.label}</td>
+            <td>${formatCurrency(unitEstimated)}</td>
+            <td>${formatCoefficient(coefficient)}</td>
+            <td>${formatCurrency(correctionFigure)}</td>
+            <td>${formatCurrency(correctedUnit)}</td>
+          `;
+          rectificationBody.appendChild(rectRow);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- add a rectification table to the admin cost estimator view to display corrected unit costs
- extend the cost calculator script to derive correction figures from the existing coefficients

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6137434948326bdddd2e8418a4053